### PR TITLE
fix: remove check for instanceof

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,7 +125,7 @@ class ScmRouter extends Scm {
             if (config && typeof config.scmContext === 'string') {
                 const scm = this.scms[config.scmContext];
 
-                if (scm && scm instanceof Scm) {
+                if (scm) {
                     return resolve(scm);
                 }
             }


### PR DESCRIPTION
This check was  never true even with the old code. 
`scm-github instanceof Scm` returns `false`

Currently, it keeps going to `Not implemented`

Related issue: https://stackoverflow.com/questions/38747538/javascript-classes-using-extends-returning-false-with-instanceof