### PR TITLE
feat: Use semantic release template. BREAKING CHANGE: bump version

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,19 +1,16 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
-        steps:
-            - install: npm install semantic-release
-            - publish: npm run semantic-release
+        requires: [main]
+        template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM
             - NPM_TOKEN


### PR DESCRIPTION
Need to bump major version

This PR uses the semantic release template and new workflow

Related to https://github.com/screwdriver-cd/scm-router/pull/6