### PR TITLE
feat(911): Add getChangedFiles method

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install screwdriver-scm-router
 
 ### Interface
 
-It will initialize any routers specified in the [default.yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml#L123-L156) under the `scms` keyword.
+It will initialize any routers specified in the [default.yaml](https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml#L147-L185) under the `scms` keyword.
 
 **Example scm yaml section:**
 ```

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ class ScmRouter extends Scm {
                     throw new Error('No scm config passed in.');
                 }
 
-                const options = hoek.applyToDefaults({ displayName }, scm.config);  // Add displayName to scm options
+                const options = hoek.applyToDefaults({ displayName }, scm.config); // Add displayName to scm options
 
                 this.loadPlugin(scm.plugin, options);
             });
@@ -272,6 +272,17 @@ class ScmRouter extends Scm {
      */
     _getFile(config) {
         return this.chooseScm(config).then(scm => scm.getFile(config));
+    }
+
+    /**
+     * Fetch changed files
+     * @method _getChangedFiles
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Promise}                        Changed files for scmContext
+     */
+    _getChangedFiles(config) {
+        return this.chooseScm(config).then(scm => scm.getChangedFiles(config));
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
   ],
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.9.1",
-    "eslint-config-screwdriver": "^2.0.9",
-    "hoek": "^4.1.1",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.0",
+    "hoek": "^5.0.3",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -10,7 +10,7 @@ jobs:
 
     publish:
         requires: [main]
-        template: screwdriver-cd/semantic-release 
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -47,6 +47,7 @@ describe('index test', () => {
             'getCommitSha',
             'updateCommitStatus',
             'getFile',
+            'getChangedFiles',
             'getOpenedPRs',
             'getPrInfo'
         ].forEach((method) => {
@@ -742,6 +743,25 @@ describe('index test', () => {
                     assert.notCalled(scmGitlab.getFile);
                     assert.calledOnce(exampleScm.getFile);
                     assert.calledWith(exampleScm.getFile, config);
+                });
+        });
+    });
+
+    describe('_getChangedFiles', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin getChangedFiles', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+
+            return scm._getChangedFiles(config)
+                .then((result) => {
+                    assert.strictEqual(result, 'example');
+                    assert.notCalled(scmGithub.getChangedFiles);
+                    assert.notCalled(scmGitlab.getChangedFiles);
+                    assert.calledOnce(exampleScm.getChangedFiles);
+                    assert.calledWith(exampleScm.getChangedFiles, config);
                 });
         });
     });


### PR DESCRIPTION
## Context
Need to implement the `_getChangedFiles` method here since the newest scm-base expects it.

## Objective
Adding `_getChangedFiles` method.

## Related links
Related to https://github.com/screwdriver-cd/scm-base/pull/49
Original issue https://github.com/screwdriver-cd/screwdriver/issues/911