### PR TITLE
feat(1319): Add getOrgPermissions

### DIFF
--- a/index.js
+++ b/index.js
@@ -236,6 +236,17 @@ class ScmRouter extends Scm {
     }
 
     /**
+     * Get a users permissions on an organization
+     * @method getOrgPermissions
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Promise}
+     */
+    _getOrgPermissions(config) {
+        return this.chooseScm(config).then(scm => scm.getOrgPermissions(config));
+    }
+
+    /**
      * Get a commit sha for a specific repo#branch or pull request
      * @method _getCommitSha
      * @param  {Object}     config              Configuration

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
-    "eslint-config-screwdriver": "^3.0.0",
-    "hoek": "^5.0.3",
-    "jenkins-mocha": "^4.0.0",
+    "eslint-config-screwdriver": "^3.0.1",
+    "hoek": "^5.0.4",
+    "jenkins-mocha": "^6.0.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"
   },
   "dependencies": {
-    "async": "^2.0.1",
-    "screwdriver-scm-base": "^4.0.1"
+    "async": "^2.6.1",
+    "screwdriver-scm-base": "^4.4.3"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -44,6 +44,7 @@ describe('index test', () => {
             'decorateCommit',
             'decorateAuthor',
             'getPermissions',
+            'getOrgPermissions',
             'getCommitSha',
             'updateCommitStatus',
             'getFile',
@@ -675,7 +676,7 @@ describe('index test', () => {
     describe('_getPermissions', () => {
         const config = { scmContext: 'example.context' };
 
-        it('call origin getPermissons', () => {
+        it('call origin getPermissions', () => {
             const scmGithub = scm.scms['github.context'];
             const exampleScm = scm.scms['example.context'];
             const scmGitlab = scm.scms['gitlab.context'];
@@ -687,6 +688,25 @@ describe('index test', () => {
                     assert.notCalled(scmGitlab.getPermissions);
                     assert.calledOnce(exampleScm.getPermissions);
                     assert.calledWith(exampleScm.getPermissions, config);
+                });
+        });
+    });
+
+    describe('_getOrgPermissions', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin getOrgPermissions', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+
+            return scm._getOrgPermissions(config)
+                .then((result) => {
+                    assert.strictEqual(result, 'example');
+                    assert.notCalled(scmGithub.getOrgPermissions);
+                    assert.notCalled(scmGitlab.getOrgPermissions);
+                    assert.calledOnce(exampleScm.getOrgPermissions);
+                    assert.calledWith(exampleScm.getOrgPermissions, config);
                 });
         });
     });


### PR DESCRIPTION
Adding getOrgPermissions method to scm-router to match scm-base

Also update jenkins-mocha to 6.0.0 to address vulnerabilities

Related to https://github.com/screwdriver-cd/scm-github/pull/105
Issue: https://github.com/screwdriver-cd/screwdriver/issues/1319