### PR TITLE
feat(1355): Add PR comment support [3]

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,17 @@ class ScmRouter extends Scm {
     }
 
     /**
+     * Add a comment on a pull request
+     * @method _addPrComment
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Promise}
+     */
+    _addPrComment(config) {
+        return this.chooseScm(config).then(scm => scm.addPrComment(config));
+    }
+
+    /**
      * Update the commit status for a given repo and sha
      * @method _updateCommitStatus
      * @param  {Object}     config              Configuration

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "async": "^2.6.1",
-    "screwdriver-scm-base": "^4.4.3"
+    "screwdriver-scm-base": "^5.0.0"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,6 +46,7 @@ describe('index test', () => {
             'getPermissions',
             'getOrgPermissions',
             'getCommitSha',
+            'addPrComment',
             'updateCommitStatus',
             'getFile',
             'getChangedFiles',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -730,6 +730,25 @@ describe('index test', () => {
         });
     });
 
+    describe('_addPrComment', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin addPrComment', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+
+            return scm._addPrComment(config)
+                .then((result) => {
+                    assert.strictEqual(result, 'example');
+                    assert.notCalled(scmGithub.addPrComment);
+                    assert.notCalled(scmGitlab.addPrComment);
+                    assert.calledOnce(exampleScm.addPrComment);
+                    assert.calledWith(exampleScm.addPrComment, config);
+                });
+        });
+    });
+
     describe('_updateCommitStatus', () => {
         const config = { scmContext: 'example.context' };
 


### PR DESCRIPTION
## Context
It would be nice for users to be able to comment back on PRs through a build with relevant metadata.

## Objective
This PR adds addPrComment method to the router.

## Related links
Related to https://github.com/screwdriver-cd/screwdriver/issues/1355