### PR TITLE
fix: fix parsed hook response

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ class ScmRouter extends Scm {
      * @return {Promise}                     scm object
      */
     chooseWebhookScm(headers, payload) {
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             // choose a webhook scm module, or null if there is no suitable one
             async.detect(this.scms, (scm, cb) => {
                 scm.canHandleWebhook(headers, payload)
@@ -103,13 +103,7 @@ class ScmRouter extends Scm {
                     }).catch(() => {
                         cb(null);
                     });
-            }, (ret) => {
-                if (ret === null) {
-                    return reject(new Error('there is no suitable webhook module'));
-                }
-
-                return resolve(ret);
-            });
+            }, ret => resolve(ret));
         });
     }
 
@@ -177,7 +171,8 @@ class ScmRouter extends Scm {
      * @return {Promise}
      */
     _parseHook(headers, payload) {
-        return this.chooseWebhookScm(headers, payload).then(scm => scm.parseHook(headers, payload));
+        return this.chooseWebhookScm(headers, payload)
+            .then(scm => (scm ? scm.parseHook(headers, payload) : null));
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const Scm = require('screwdriver-scm-base');
 const async = require('async');
 const hoek = require('hoek');
+const winston = require('winston');
 
 class ScmRouter extends Scm {
     /**
@@ -172,7 +173,15 @@ class ScmRouter extends Scm {
      */
     _parseHook(headers, payload) {
         return this.chooseWebhookScm(headers, payload)
-            .then(scm => (scm ? scm.parseHook(headers, payload) : null));
+            .then((scm) => {
+                if (!scm) {
+                    winston.info('Webhook does not match any expected events or actions.');
+
+                    return null;
+                }
+
+                return scm.parseHook(headers, payload);
+            });
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "dependencies": {
     "async": "^2.6.1",
-    "screwdriver-scm-base": "^5.0.0"
+    "screwdriver-scm-base": "^5.0.0",
+    "winston": "^3.1.0"
   },
   "release": {
     "debug": false,


### PR DESCRIPTION
### Context
Webhooks which don't match handlable events or actions return error.
It would be better to return status 204.

### Objectives
Return null for webhooks which don't match any expected events or actions, in order to return 204 in webhook plugin.
https://github.com/screwdriver-cd/screwdriver/blob/c47c0e6a74e30ac7741241670fe252ab88b0d15c/plugins/webhooks/index.js#L579