### PR TITLE
feat(823): [3] add _getCommitRefSha()

### DIFF
--- a/index.js
+++ b/index.js
@@ -262,6 +262,17 @@ class ScmRouter extends Scm {
     }
 
     /**
+     * Get a commit sha from a reference
+     * @method _getCommitRefSha
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Promise}
+     */
+    _getCommitRefSha(config) {
+        return this.chooseScm(config).then(scm => scm.getCommitRefSha(config));
+    }
+
+    /**
      * Add a comment on a pull request
      * @method _addPrComment
      * @param  {Object}     config              Configuration

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -46,6 +46,7 @@ describe('index test', () => {
             'getPermissions',
             'getOrgPermissions',
             'getCommitSha',
+            'getCommitRefSha',
             'addPrComment',
             'updateCommitStatus',
             'getFile',
@@ -727,6 +728,25 @@ describe('index test', () => {
                     assert.notCalled(scmGitlab.getCommitSha);
                     assert.calledOnce(exampleScm.getCommitSha);
                     assert.calledWith(exampleScm.getCommitSha, config);
+                });
+        });
+    });
+
+    describe('_getCommitRefSha', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin getCommitRefSha', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+
+            return scm._getCommitRefSha(config)
+                .then((result) => {
+                    assert.strictEqual(result, 'example');
+                    assert.notCalled(scmGithub.getCommitRefSha);
+                    assert.notCalled(scmGitlab.getCommitRefSha);
+                    assert.calledOnce(exampleScm.getCommitRefSha);
+                    assert.calledWith(exampleScm.getCommitRefSha, config);
                 });
         });
     });


### PR DESCRIPTION
This PR creates the route of [getCommitRefSha](https://octokit.github.io/rest.js/#api-Repos-getCommitRefSha).
It's used for getting `sha` when `release` and `tag` triggers are fired.

Related Issue: https://github.com/screwdriver-cd/screwdriver/issues/823
Blocked By: 
- https://github.com/screwdriver-cd/data-schema/pull/322
- https://github.com/screwdriver-cd/scm-base/pull/68