### PR TITLE
fix: log error when checking `canHandleWebhook`

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,8 @@ class ScmRouter extends Scm {
                 scm.canHandleWebhook(headers, payload)
                     .then((result) => {
                         cb(result === false ? null : scm);
-                    }).catch(() => {
+                    }).catch((err) => {
+                        logger.error(err);
                         cb(null);
                     });
             }, ret => resolve(ret));


### PR DESCRIPTION
## Context

Errors from `canHandleWebhook` are missing and hard to trace

## Objective

add more logging

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
