### PR TITLE
fix(1079): Fix autoDeployKeyGenerationEnabled to not return a promise

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,6 +178,17 @@ class ScmRouter extends Scm {
 
     /**
      * Parse the url for a repo for the specific source control
+     * @method _addDeployKey
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Promise}
+     */
+    _addDeployKey(config) {
+        return this.chooseScm(config).then(scm => scm.addDeployKey(config));
+    }
+
+    /**
+     * Parse the url for a repo for the specific source control
      * @method _parseUrl
      * @param  {Object}     config              Configuration
      * @param  {String}     config.scmContext   Name of scm context

--- a/index.js
+++ b/index.js
@@ -178,17 +178,6 @@ class ScmRouter extends Scm {
 
     /**
      * Parse the url for a repo for the specific source control
-     * @method _addDeployKey
-     * @param  {Object}     config              Configuration
-     * @param  {String}     config.scmContext   Name of scm context
-     * @return {Promise}
-     */
-    _addDeployKey(config) {
-        return this.chooseScm(config).then(scm => scm.addDeployKey(config));
-    }
-
-    /**
-     * Parse the url for a repo for the specific source control
      * @method _parseUrl
      * @param  {Object}     config              Configuration
      * @param  {String}     config.scmContext   Name of scm context

--- a/index.js
+++ b/index.js
@@ -156,17 +156,17 @@ class ScmRouter extends Scm {
 
     /**
      * Returns whether auto deploy key generation is enabled on or not
-     * @method _autoDeployKeyGenerationEnabled
+     * @method autoDeployKeyGenerationEnabled
      * @param  {Object}     config              Configuration
      * @param  {String}     config.scmContext   Name of scm context
-     * @return {Promise}                        Resolves when operation completed without failure
+     * @return {Boolean}                        Resolves when operation completed without failure
      */
-    _autoDeployKeyGenerationEnabled(config) {
-        return this.chooseScm(config).then(scm => scm.autoDeployKeyGenerationEnabled(config));
+    autoDeployKeyGenerationEnabled(config) {
+        return this.scms[config.scmContext].autoDeployKeyGenerationEnabled();
     }
 
     /**
-     * Parse the url for a repo for the specific source control
+     * Generate and add the public deploy key to the specific scm
      * @method _addDeployKey
      * @param  {Object}     config              Configuration
      * @param  {String}     config.scmContext   Name of scm context

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,18 +38,7 @@ describe('index test', () => {
             'dummyRejectFunction',
             'addWebhook',
             'addDeployKey',
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
             'autoDeployKeyGenerationEnabled',
-=======
->>>>>>> 0a3f386... feat(scm-router): Add addDeployKey method
-=======
-            'checkAutoDeployKeyGeneration',
->>>>>>> e6b399f... feat(): add tests for checkAutoDeployKeyGeneration
-=======
-            'autoDeployKeyGenerationEnabled',
->>>>>>> 02ba650... refactor(): change function name to autoDeployKeyGenerationEnabled
             'parseUrl',
             'parseHook',
             'getCheckoutCommand',
@@ -76,6 +65,7 @@ describe('index test', () => {
         mock.canHandleWebhook = sinon.stub().resolves(true);
         mock.getScmContexts = sinon.stub().returns([`${plugin}.context`]);
         mock.getDisplayName = sinon.stub().returns(plugin);
+        mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
 
         return mock;
     };
@@ -593,25 +583,6 @@ describe('index test', () => {
         });
     });
 
-    describe('_autoDeployKeyGenerationEnabled', () => {
-        const config = { scmContext: 'example.context' };
-
-        it('call origin autoDeployKeyGenerationEnabled', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-            
-            return scm._autoDeployKeyGenerationEnabled(config)
-                .then((result) => {
-                    assert.strictEqual(result, 'example');
-                    assert.notCalled(scmGithub.autoDeployKeyGenerationEnabled);
-                    assert.notCalled(scmGitlab.autoDeployKeyGenerationEnabled);
-                    assert.calledOnce(exampleScm.autoDeployKeyGenerationEnabled);
-                    assert.calledWith(exampleScm.autoDeployKeyGenerationEnabled, config);
-                });
-        });
-    });
-
     describe('_parseUrl', () => {
         const config = { scmContext: 'example.context' };
 
@@ -1011,6 +982,22 @@ describe('index test', () => {
             assert.notCalled(scmGithub.getDisplayName);
             assert.notCalled(scmGitlab.getDisplayName);
             assert.calledOnce(exampleScm.getDisplayName);
+        });
+    });
+
+    describe('autoDeployKeyGenerationEnabled', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin autoDeployKeyGenerationEnabled', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+            const result = scm.autoDeployKeyGenerationEnabled(config);
+
+            assert.strictEqual(result, 'example');
+            assert.notCalled(scmGithub.autoDeployKeyGenerationEnabled);
+            assert.notCalled(scmGitlab.autoDeployKeyGenerationEnabled);
+            assert.calledOnce(exampleScm.autoDeployKeyGenerationEnabled);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -39,9 +39,13 @@ describe('index test', () => {
             'addWebhook',
             'addDeployKey',
 <<<<<<< HEAD
+<<<<<<< HEAD
             'autoDeployKeyGenerationEnabled',
 =======
 >>>>>>> 0a3f386... feat(scm-router): Add addDeployKey method
+=======
+            'checkAutoDeployKeyGeneration',
+>>>>>>> e6b399f... feat(): add tests for checkAutoDeployKeyGeneration
             'parseUrl',
             'parseHook',
             'getCheckoutCommand',
@@ -592,7 +596,7 @@ describe('index test', () => {
             const scmGithub = scm.scms['github.context'];
             const exampleScm = scm.scms['example.context'];
             const scmGitlab = scm.scms['gitlab.context'];
-
+            
             return scm._autoDeployKeyGenerationEnabled(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,7 +38,10 @@ describe('index test', () => {
             'dummyRejectFunction',
             'addWebhook',
             'addDeployKey',
+<<<<<<< HEAD
             'autoDeployKeyGenerationEnabled',
+=======
+>>>>>>> 0a3f386... feat(scm-router): Add addDeployKey method
             'parseUrl',
             'parseHook',
             'getCheckoutCommand',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,12 +40,16 @@ describe('index test', () => {
             'addDeployKey',
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
             'autoDeployKeyGenerationEnabled',
 =======
 >>>>>>> 0a3f386... feat(scm-router): Add addDeployKey method
 =======
             'checkAutoDeployKeyGeneration',
 >>>>>>> e6b399f... feat(): add tests for checkAutoDeployKeyGeneration
+=======
+            'autoDeployKeyGenerationEnabled',
+>>>>>>> 02ba650... refactor(): change function name to autoDeployKeyGenerationEnabled
             'parseUrl',
             'parseHook',
             'getCheckoutCommand',


### PR DESCRIPTION
## Context

Fixes screwdriver-cd/screwdriver#1079

## Objective

This PR configures autoKeyGenerationEnabled() to return a non-promise based value

## References

screwdriver-cd/screwdriver#1079

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
