### PR TITLE
feat: upgrade hapiv19 dependencies. BREAKING CHANGE: scm-base version

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const Scm = require('screwdriver-scm-base');
 const async = require('async');
-const hoek = require('hoek');
+const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
 
 class ScmRouter extends Scm {

--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "hoek": "^5.0.4",
     "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"
   },
   "dependencies": {
     "async": "^2.6.1",
-    "screwdriver-scm-base": "^6.0.0",
-    "screwdriver-logger": "^1.0.0"
+    "@hapi/hoek": "^9.0.4",
+    "screwdriver-logger": "^1.0.0",
+    "screwdriver-scm-base": "git://github.com/screwdriver-cd/scm-base.git#hapi-v19"
   },
   "release": {
     "debug": false,

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
+    "mocha": "^8.1.2",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"
   },

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
   "name": "screwdriver-scm-router",
-  "version": "2.0.0",
+  "version": "6.0.0",
   "description": "A generic plugin for routing builds to specified scm",
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "jenkins-mocha --recursive",
+    "test": "mocha --recursive",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
   "repository": {
@@ -36,7 +36,6 @@
     "chai": "^3.5.0",
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.1",
-    "jenkins-mocha": "^8.0.0",
     "mockery": "^2.0.0",
     "sinon": "^2.3.4"
   },
@@ -44,7 +43,7 @@
     "async": "^2.6.1",
     "@hapi/hoek": "^9.0.4",
     "screwdriver-logger": "^1.0.0",
-    "screwdriver-scm-base": "git://github.com/screwdriver-cd/scm-base.git#hapi-v19"
+    "screwdriver-scm-base": "^7.0.0"
   },
   "release": {
     "debug": false,

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,5 +1,5 @@
 shared:
-    image: node:8
+    image: node:12
 
 jobs:
     main:


### PR DESCRIPTION
## Context

Screwdriver hapi.js dependencies are outdated and not supported anymore.

## Objective

This PR majorly upgrades @hapi/joi version and fixes all schema related changes to be compatible with latest @hapi js dependencies.

## References

https://github.com/screwdriver-cd/screwdriver/issues/1958

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
