### PR TITLE
feat(2437): Add method to get read only flag [3]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ npm-debug.log
 .DS_STORE
 .*.swp
 .nyc_output/
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ const async = require('async');
 const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
 
-const MATCHED_SCM_HOSTNAME = 1;
-
 class ScmRouter extends Scm {
     /**
      * Constructs a router for different scm strategies
@@ -414,7 +412,7 @@ class ScmRouter extends Scm {
      */
     _getScmContext({ hostname }) {
         return Object.keys(this.scms).find(scmContext =>
-            scmContext.split(':')[MATCHED_SCM_HOSTNAME] === hostname);
+            scmContext.split(':')[1] === hostname);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -409,8 +409,8 @@ class ScmRouter extends Scm {
      * Get an scm context given a hostname (e.g. github:github.com)
      * @method _getScmContext
      * @param  {Object} config
-     * @param  {String} config.hostname Hostname for scmContext (e.g. github.com)
-     * @return {String}                 Full scmContext (e.g. github:github.com)
+     * @param  {String} [config.hostname]   Hostname for scmContext (e.g. github.com)
+     * @return {String}                     Full scmContext (e.g. github:github.com)
      */
     _getScmContext({ hostname }) {
         return Object.keys(this.scms).find(scmContext =>
@@ -439,6 +439,17 @@ class ScmRouter extends Scm {
      */
     getDisplayName(config) {
         return this.scms[config.scmContext].getDisplayName();
+    }
+
+    /**
+     * Get username of scmContext
+     * @method getUsername
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {String}                         Username of scmContext
+     */
+    getUsername(config) {
+        return this.scms[config.scmContext].getUsername();
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const async = require('async');
 const hoek = require('@hapi/hoek');
 const logger = require('screwdriver-logger');
 
+const MATCHED_SCM_HOSTNAME = 1;
+
 class ScmRouter extends Scm {
     /**
      * Constructs a router for different scm strategies
@@ -395,12 +397,24 @@ class ScmRouter extends Scm {
     }
 
     /**
-     * Get an array of scm context (e.g. [github:github.com, gitlab:mygitlab])
+     * Get an array of scm contexts (e.g. [github:github.com, gitlab:mygitlab])
      * @method _getScmContexts
      * @return {Array}
      */
     _getScmContexts() {
         return Object.keys(this.scms);
+    }
+
+    /**
+     * Get an scm context given a hostname (e.g. github:github.com)
+     * @method _getScmContext
+     * @param  {Object} config
+     * @param  {String} config.hostname Hostname for scmContext (e.g. github.com)
+     * @return {String}                 Full scmContext (e.g. github:github.com)
+     */
+    _getScmContext({ hostname }) {
+        return Object.keys(this.scms).find(scmContext =>
+            scmContext.split(':')[MATCHED_SCM_HOSTNAME] === hostname);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -442,25 +442,18 @@ class ScmRouter extends Scm {
     }
 
     /**
-     * Get username of scmContext
-     * @method getUsername
+     * Get read only config
+     * @method getReadOnlyInfo
      * @param  {Object}     config              Configuration
      * @param  {String}     config.scmContext   Name of scm context
-     * @return {String}                         Username of scmContext
+     * @return {Object}                         Read only config of scmContext (e.g.: {
+     *                                              "enabled": true,
+     *                                              "username": 'headless-user',
+     *                                              "accessToken": 'token'
+     *                                          })
      */
-    getUsername(config) {
-        return this.scms[config.scmContext].getUsername();
-    }
-
-    /**
-     * Get display name of scmContext
-     * @method getDisplayName
-     * @param  {Object}     config              Configuration
-     * @param  {String}     config.scmContext   Name of scm context
-     * @return {String}                         display name of scmContext
-     */
-    readOnlyEnabled(config) {
-        return this.scms[config.scmContext].readOnlyEnabled();
+    getReadOnlyInfo(config) {
+        return this.scms[config.scmContext].getReadOnlyInfo();
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -428,6 +428,17 @@ class ScmRouter extends Scm {
     }
 
     /**
+     * Get display name of scmContext
+     * @method getDisplayName
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {String}                         display name of scmContext
+     */
+    readOnlyEnabled(config) {
+        return this.scms[config.scmContext].readOnlyEnabled();
+    }
+
+    /**
      * Get branch info of scmContext
      * @method _getBranchList
      * @param  {Object}     config              Configuration

--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
     "sinon": "^2.3.4"
   },
   "dependencies": {
-    "async": "^2.6.1",
     "@hapi/hoek": "^9.0.4",
+    "async": "^2.6.3",
     "screwdriver-logger": "^1.0.0",
     "screwdriver-scm-base": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@hapi/hoek": "^9.0.4",
     "async": "^2.6.3",
     "screwdriver-logger": "^1.0.0",
-    "screwdriver-scm-base": "^7.0.0"
+    "screwdriver-scm-base": "^7.1.3"
   },
   "release": {
     "debug": false,

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,6 +72,7 @@ describe('index test', () => {
         mock.getScmContexts = sinon.stub().returns([`${plugin}:${plugin}.com`]);
         mock.getScmContext = sinon.stub().returns(`${plugin}:${plugin}.com`);
         mock.getDisplayName = sinon.stub().returns(plugin);
+        mock.getUsername = sinon.stub().returns(plugin);
         mock.readOnlyEnabled = sinon.stub().returns(plugin);
         mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
         mock.getWebhookEventsMapping = sinon.stub().returns({ pr: 'pull_request' });
@@ -926,6 +927,19 @@ describe('index test', () => {
             assert.notCalled(scmGithub.getDisplayName);
             assert.notCalled(scmGitlab.getDisplayName);
             assert.calledOnce(exampleScm.getDisplayName);
+        });
+    });
+
+    describe('getUsername', () => {
+        const config = { scmContext: exampleScmContext };
+
+        it('call origin getUsername', () => {
+            const result = scm.getUsername(config);
+
+            assert.strictEqual(result, 'example');
+            assert.notCalled(scmGithub.getUsername);
+            assert.notCalled(scmGitlab.getUsername);
+            assert.calledOnce(exampleScm.getUsername);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -72,8 +72,7 @@ describe('index test', () => {
         mock.getScmContexts = sinon.stub().returns([`${plugin}:${plugin}.com`]);
         mock.getScmContext = sinon.stub().returns(`${plugin}:${plugin}.com`);
         mock.getDisplayName = sinon.stub().returns(plugin);
-        mock.getUsername = sinon.stub().returns(plugin);
-        mock.readOnlyEnabled = sinon.stub().returns(plugin);
+        mock.getReadOnlyInfo = sinon.stub().returns(plugin);
         mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
         mock.getWebhookEventsMapping = sinon.stub().returns({ pr: 'pull_request' });
 
@@ -930,29 +929,16 @@ describe('index test', () => {
         });
     });
 
-    describe('getUsername', () => {
+    describe('getReadOnlyInfo', () => {
         const config = { scmContext: exampleScmContext };
 
-        it('call origin getUsername', () => {
-            const result = scm.getUsername(config);
+        it('call origin getReadOnlyInfo', () => {
+            const result = scm.getReadOnlyInfo(config);
 
             assert.strictEqual(result, 'example');
-            assert.notCalled(scmGithub.getUsername);
-            assert.notCalled(scmGitlab.getUsername);
-            assert.calledOnce(exampleScm.getUsername);
-        });
-    });
-
-    describe('readOnlyEnabled', () => {
-        const config = { scmContext: exampleScmContext };
-
-        it('call origin getDisplayName', () => {
-            const result = scm.readOnlyEnabled(config);
-
-            assert.strictEqual(result, 'example');
-            assert.notCalled(scmGithub.readOnlyEnabled);
-            assert.notCalled(scmGitlab.readOnlyEnabled);
-            assert.calledOnce(exampleScm.readOnlyEnabled);
+            assert.notCalled(scmGithub.getReadOnlyInfo);
+            assert.notCalled(scmGitlab.getReadOnlyInfo);
+            assert.calledOnce(exampleScm.getReadOnlyInfo);
         });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,6 +16,9 @@ describe('index test', () => {
     let githubScmMock;
     let gitlabScmMock;
     let exampleScmMock;
+    let scmGithub;
+    let scmGitlab;
+    let exampleScm;
     const githubPluginOptions = {
         oauthClientId: 'OAUTH_CLIENT_ID',
         oauthClientSecret: 'OAUTH_CLIENT_SECRET',
@@ -30,6 +33,9 @@ describe('index test', () => {
     const examplePluginOptions = {
         somekey: 'somevalue'
     };
+    const githubScmContext = 'github:github.com';
+    const exampleScmContext = 'example:example.com';
+    const gitlabScmContext = 'gitlab:gitlab.com';
     const initMock = (plugin) => {
         const mock = {};
 
@@ -63,7 +69,8 @@ describe('index test', () => {
         mock.getBellConfiguration = sinon.stub().resolves({ [plugin]: `${plugin}Bell` });
         mock.stats = sinon.stub().returns({ [plugin]: { requests: plugin } });
         mock.canHandleWebhook = sinon.stub().resolves(true);
-        mock.getScmContexts = sinon.stub().returns([`${plugin}.context`]);
+        mock.getScmContexts = sinon.stub().returns([`${plugin}:${plugin}.com`]);
+        mock.getScmContext = sinon.stub().returns(`${plugin}:${plugin}.com`);
         mock.getDisplayName = sinon.stub().returns(plugin);
         mock.readOnlyEnabled = sinon.stub().returns(plugin);
         mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
@@ -95,20 +102,24 @@ describe('index test', () => {
 
         scm = new Scm({
             scms: {
-                'github.com': {
+                github: {
                     plugin: 'github',
                     config: githubPluginOptions
                 },
-                'example.com': {
+                example: {
                     plugin: 'example',
                     config: examplePluginOptions
                 },
-                'gitlab.com': {
+                gitlab: {
                     plugin: 'gitlab',
                     config: gitlabPluginOptions
                 }
             }
         });
+
+        scmGithub = scm.scms[githubScmContext];
+        exampleScm = scm.scms[exampleScmContext];
+        scmGitlab = scm.scms[gitlabScmContext];
     });
 
     afterEach(() => {
@@ -135,15 +146,15 @@ describe('index test', () => {
             );
             expectedGithubOptions = Object.assign(
                 githubOptions,
-                { displayName: 'github.com' }
+                { displayName: 'github' }
             );
             expectedExampleOptions = Object.assign(
                 exampleOptions,
-                { displayName: 'example.com' }
+                { displayName: 'example' }
             );
             expectedGitlabOptions = Object.assign(
                 gitlabOptions,
-                { displayName: 'gitlab.com' }
+                { displayName: 'gitlab' }
             );
         });
 
@@ -153,11 +164,11 @@ describe('index test', () => {
             }, Error, 'No scm config passed in.');
         });
 
-        it('does not throws an error when the scm.config does not exist', () => {
+        it('does not throw an error when the scm.config does not exist', () => {
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': {
+                        github: {
                             plugin: 'github'
                         }
                     }
@@ -169,7 +180,7 @@ describe('index test', () => {
             assert.throws(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': 'value'
+                        github: 'value'
                     }
                 });
             }, Error, 'No scm config passed in.');
@@ -183,11 +194,11 @@ describe('index test', () => {
             }, Error, 'No scm config passed in.');
         });
 
-        it('does not throws an error when the config is an empty map', () => {
+        it('does not throw an error when the config is an empty map', () => {
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': {
+                        github: {
                             plugin: 'github',
                             config: {}
                         }
@@ -200,7 +211,7 @@ describe('index test', () => {
             assert.throws(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': {
+                        github: {
                             plugin: 'github',
                             config: 'config'
                         }
@@ -213,11 +224,11 @@ describe('index test', () => {
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'DNE.com': {
+                        DNE: {
                             plugin: 'DNE',
                             config: {}
                         },
-                        'example.com': {
+                        example: {
                             plugin: 'example',
                             config: examplePluginOptions
                         }
@@ -230,11 +241,11 @@ describe('index test', () => {
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'router.com': {
+                        router: {
                             plugin: 'router',
                             config: {}
                         },
-                        'example.com': {
+                        example: {
                             plugin: 'example',
                             config: examplePluginOptions
                         }
@@ -244,10 +255,6 @@ describe('index test', () => {
         });
 
         it('registers multiple plugins', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
             assert.deepEqual(exampleScm.constructorParams, expectedExampleOptions);
             assert.deepEqual(scmGitlab.constructorParams, expectedGitlabOptions);
@@ -261,7 +268,7 @@ describe('index test', () => {
                 }]
             });
 
-            const exampleScm = scm.scms['example.context'];
+            exampleScm = scm.scms[exampleScmContext];
 
             assert.deepEqual(exampleScm.constructorParams, expectedExampleOptions);
         });
@@ -271,11 +278,11 @@ describe('index test', () => {
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': {
+                        github: {
                             plugin: 'github',
                             config: githubPluginOptions
                         },
-                        'example.com': {
+                        example: {
                             plugin: 'example',
                             config: examplePluginOptions
                         }
@@ -283,26 +290,26 @@ describe('index test', () => {
                 });
             });
 
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
+            scmGithub = scm.scms[githubScmContext];
+            exampleScm = scm.scms[exampleScmContext];
+            scmGitlab = scm.scms[gitlabScmContext];
 
             assert.isUndefined(scmGithub);
             assert.isUndefined(scmGitlab);
             assert.deepEqual(exampleScm.constructorParams,
-                Object.assign(exampleOptions, { displayName: 'example.com' }));
+                Object.assign(exampleOptions, { displayName: 'example' }));
         });
 
         it('does not throw an error and skip when getScmContexts return is not a string', () => {
-            githubScmMock.getScmContexts.returns([{ somekey: 'github.context' }]);
+            githubScmMock.getScmContexts.returns([{ somekey: githubScmContext }]);
             assert.doesNotThrow(() => {
                 scm = new Scm({
                     scms: {
-                        'github.com': {
+                        github: {
                             plugin: 'github',
                             config: githubPluginOptions
                         },
-                        'example.com': {
+                        example: {
                             plugin: 'example',
                             config: examplePluginOptions
                         }
@@ -310,9 +317,9 @@ describe('index test', () => {
                 });
             });
 
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
+            scmGithub = scm.scms[githubScmContext];
+            exampleScm = scm.scms[exampleScmContext];
+            scmGitlab = scm.scms[gitlabScmContext];
 
             assert.isUndefined(scmGithub);
             assert.isUndefined(scmGitlab);
@@ -347,7 +354,7 @@ describe('index test', () => {
         beforeEach(() => {
             scm = new Scm({
                 scms: {
-                    'github.com': {
+                    github: {
                         plugin: 'github',
                         config: githubPluginOptions
                     }
@@ -361,24 +368,24 @@ describe('index test', () => {
             );
             expectedGithubOptions = Object.assign(
                 githubOptions,
-                { displayName: 'github.com' }
+                { displayName: 'github' }
             );
             expectedExampleOptions = Object.assign(
                 exampleOptions,
-                { displayName: 'example.com' }
+                { displayName: 'example' }
             );
         });
 
         it('registers a plugin', () => {
             const config = Object.assign(
-                { displayName: 'example.com' },
+                { displayName: 'example' },
                 examplePluginOptions
             );
 
             scm.loadPlugin('example', config);
 
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
+            scmGithub = scm.scms[githubScmContext];
+            exampleScm = scm.scms[exampleScmContext];
 
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
             assert.deepEqual(exampleScm.constructorParams, expectedExampleOptions);
@@ -393,14 +400,14 @@ describe('index test', () => {
                 scm.loadPlugin('DNE', config);
             });
 
-            const scmGithub = scm.scms['github.context'];
+            scmGithub = scm.scms[githubScmContext];
 
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
         });
 
         it('does not throw an error when scm-router plugin is specified for scms setting', () => {
             const config = Object.assign(
-                { displayName: 'example.com' },
+                { displayName: 'example' },
                 examplePluginOptions
             );
 
@@ -408,9 +415,9 @@ describe('index test', () => {
                 scm.loadPlugin('router', config);
             });
 
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
+            scmGithub = scm.scms[githubScmContext];
+            exampleScm = scm.scms[exampleScmContext];
+            scmGitlab = scm.scms[gitlabScmContext];
 
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
             assert.isUndefined(scmGitlab);
@@ -420,7 +427,7 @@ describe('index test', () => {
         it('does not throw an error when npm module returns empty scmContext', () => {
             exampleScmMock.getScmContexts.returns(['']);
             const config = Object.assign(
-                { displayName: 'example.com' },
+                { displayName: 'example' },
                 examplePluginOptions
             );
 
@@ -428,9 +435,9 @@ describe('index test', () => {
                 scm.loadPlugin('example', config);
             });
 
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
+            scmGithub = scm.scms[githubScmContext];
+            exampleScm = scm.scms[exampleScmContext];
+            scmGitlab = scm.scms[gitlabScmContext];
 
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
             assert.isUndefined(scmGitlab);
@@ -439,13 +446,13 @@ describe('index test', () => {
 
         it('does not throw an error when scmContext already exists', () => {
             const config = Object.assign(
-                { displayName: 'github.com' },
+                { displayName: 'github' },
                 examplePluginOptions
             );
 
             scm.loadPlugin('github', config);
 
-            const scmGithub = scm.scms['github.context'];
+            scmGithub = scm.scms[githubScmContext];
 
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
         });
@@ -473,7 +480,7 @@ describe('index test', () => {
                     {
                         plugin: 'github',
                         config: {
-                            displayName: 'github.com'
+                            displayName: 'github'
                         }
                     }
                 ]
@@ -493,7 +500,7 @@ describe('index test', () => {
     });
 
     describe('chooseScm', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
         it('choose a scm module', () =>
             scm.chooseScm(config)
@@ -532,10 +539,10 @@ describe('index test', () => {
     });
 
     describe('allScm', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
         const bell = { github: 'githubBell', example: 'exampleBell', gitlab: 'gitlabBell' };
 
-        it('call all origin scm module and return conbined', () =>
+        it('call all origin scm module and return combined', () =>
             scm.allScm(module => module.getBellConfiguration(config))
                 .then((result) => {
                     assert.deepEqual(result, bell);
@@ -561,364 +568,288 @@ describe('index test', () => {
     });
 
     describe('_addWebhook', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin addWebhook', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._addWebhook(config)
+        it('call origin addWebhook', () => (
+            scm._addWebhook(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.addWebhook);
                     assert.notCalled(scmGitlab.addWebhook);
                     assert.calledOnce(exampleScm.addWebhook);
                     assert.calledWith(exampleScm.addWebhook, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_addDeployKey', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin addDeployKey', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._addDeployKey(config)
+        it('call origin addDeployKey', () => (
+            scm._addDeployKey(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.addDeployKey);
                     assert.notCalled(scmGitlab.addDeployKey);
                     assert.calledOnce(exampleScm.addDeployKey);
                     assert.calledWith(exampleScm.addDeployKey, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_parseUrl', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin parseUrl', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._parseUrl(config)
+        it('call origin parseUrl', () => (
+            scm._parseUrl(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.parseUrl);
                     assert.notCalled(scmGitlab.parseUrl);
                     assert.calledOnce(exampleScm.parseUrl);
                     assert.calledWith(exampleScm.parseUrl, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_parseHook', () => {
         const headers = { key: 'headers' };
         const payload = { key: 'payload' };
 
-        it('call origin parseHook', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._parseHook(headers, payload)
+        it('call origin parseHook', () => (
+            scm._parseHook(headers, payload)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.parseHook);
                     assert.notCalled(scmGitlab.parseHook);
                     assert.calledOnce(exampleScm.parseHook);
                     assert.calledWith(exampleScm.parseHook, headers, payload);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getCheckoutCommand', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getCheckourCommand', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getCheckoutCommand(config)
+        it('call origin getCheckourCommand', () => (
+            scm._getCheckoutCommand(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getCheckoutCommand);
                     assert.notCalled(scmGitlab.getCheckoutCommand);
                     assert.calledOnce(exampleScm.getCheckoutCommand);
                     assert.calledWith(exampleScm.getCheckoutCommand, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_decorateUrl', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin decorateUrl', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._decorateUrl(config)
+        it('call origin decorateUrl', () => (
+            scm._decorateUrl(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.decorateUrl);
                     assert.notCalled(scmGitlab.decorateUrl);
                     assert.calledOnce(exampleScm.decorateUrl);
                     assert.calledWith(exampleScm.decorateUrl, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_decorateCommit', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin decorateCommit', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._decorateCommit(config)
+        it('call origin decorateCommit', () => (
+            scm._decorateCommit(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.decorateCommit);
                     assert.notCalled(scmGitlab.decorateCommit);
                     assert.calledOnce(exampleScm.decorateCommit);
                     assert.calledWith(exampleScm.decorateCommit, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_decorateAuthor', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin decorateAuthor', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._decorateAuthor(config)
+        it('call origin decorateAuthor', () => (
+            scm._decorateAuthor(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.decorateAuthor);
                     assert.notCalled(scmGitlab.decorateAuthor);
                     assert.calledOnce(exampleScm.decorateAuthor);
                     assert.calledWith(exampleScm.decorateAuthor, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getPermissions', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getPermissions', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getPermissions(config)
+        it('call origin getPermissions', () => (
+            scm._getPermissions(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getPermissions);
                     assert.notCalled(scmGitlab.getPermissions);
                     assert.calledOnce(exampleScm.getPermissions);
                     assert.calledWith(exampleScm.getPermissions, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getOrgPermissions', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getOrgPermissions', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getOrgPermissions(config)
+        it('call origin getOrgPermissions', () => (
+            scm._getOrgPermissions(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getOrgPermissions);
                     assert.notCalled(scmGitlab.getOrgPermissions);
                     assert.calledOnce(exampleScm.getOrgPermissions);
                     assert.calledWith(exampleScm.getOrgPermissions, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getCommitSha', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getCommitSha', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getCommitSha(config)
+        it('call origin getCommitSha', () => (
+            scm._getCommitSha(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getCommitSha);
                     assert.notCalled(scmGitlab.getCommitSha);
                     assert.calledOnce(exampleScm.getCommitSha);
                     assert.calledWith(exampleScm.getCommitSha, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getCommitRefSha', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getCommitRefSha', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getCommitRefSha(config)
+        it('call origin getCommitRefSha', () => (
+            scm._getCommitRefSha(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getCommitRefSha);
                     assert.notCalled(scmGitlab.getCommitRefSha);
                     assert.calledOnce(exampleScm.getCommitRefSha);
                     assert.calledWith(exampleScm.getCommitRefSha, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_addPrComment', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin addPrComment', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._addPrComment(config)
+        it('call origin addPrComment', () => (
+            scm._addPrComment(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.addPrComment);
                     assert.notCalled(scmGitlab.addPrComment);
                     assert.calledOnce(exampleScm.addPrComment);
                     assert.calledWith(exampleScm.addPrComment, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_updateCommitStatus', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin updateCommitStatus', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._updateCommitStatus(config)
+        it('call origin updateCommitStatus', () => (
+            scm._updateCommitStatus(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.updateCommitStatus);
                     assert.notCalled(scmGitlab.updateCommitStatus);
                     assert.calledOnce(exampleScm.updateCommitStatus);
                     assert.calledWith(exampleScm.updateCommitStatus, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getFile', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getFile', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getFile(config)
+        it('call origin getFile', () => (
+            scm._getFile(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getFile);
                     assert.notCalled(scmGitlab.getFile);
                     assert.calledOnce(exampleScm.getFile);
                     assert.calledWith(exampleScm.getFile, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getChangedFiles', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getChangedFiles', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getChangedFiles(config)
+        it('call origin getChangedFiles', () => (
+            scm._getChangedFiles(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getChangedFiles);
                     assert.notCalled(scmGitlab.getChangedFiles);
                     assert.calledOnce(exampleScm.getChangedFiles);
                     assert.calledWith(exampleScm.getChangedFiles, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getOpenedPRs', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getOpenedPRs', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getOpenedPRs(config)
+        it('call origin getOpenedPRs', () => (
+            scm._getOpenedPRs(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getOpenedPRs);
                     assert.notCalled(scmGitlab.getOpenedPRs);
                     assert.calledOnce(exampleScm.getOpenedPRs);
                     assert.calledWith(exampleScm.getOpenedPRs, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getBellConfiguration', () => {
         const bell = { github: 'githubBell', example: 'exampleBell', gitlab: 'gitlabBell' };
 
-        it('call origin getBellConfiguration and return combined', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getBellConfiguration()
+        it('call origin getBellConfiguration and return combined', () => (
+            scm._getBellConfiguration()
                 .then((result) => {
                     assert.deepEqual(result, bell);
                     assert.calledOnce(scmGithub.getBellConfiguration);
                     assert.calledOnce(exampleScm.getBellConfiguration);
                     assert.calledOnce(scmGitlab.getBellConfiguration);
-                });
-        });
+                })
+        ));
     });
 
     describe('_getPrInfo', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getPrInfo', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getPrInfo(config)
+        it('call origin getPrInfo', () => (
+            scm._getPrInfo(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getPrInfo);
                     assert.notCalled(scmGitlab.getPrInfo);
                     assert.calledOnce(exampleScm.getPrInfo);
                     assert.calledWith(exampleScm.getPrInfo, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('stats', () => {
@@ -929,9 +860,6 @@ describe('index test', () => {
         };
 
         it('call origin stats', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
             const result = scm.stats();
 
             assert.deepEqual(result, stats);
@@ -942,7 +870,7 @@ describe('index test', () => {
     });
 
     describe('_getScmContexts', () => {
-        const context = ['github.context', 'example.context', 'gitlab.context'];
+        const context = [githubScmContext, exampleScmContext, gitlabScmContext];
 
         it('get registered scm list', () => {
             const result = scm._getScmContexts();
@@ -951,12 +879,20 @@ describe('index test', () => {
         });
     });
 
+    describe('_getScmContext', () => {
+        it('get scmContext that matches given hostname', () => {
+            const result = scm._getScmContext({ hostname: 'github.com' });
+
+            assert.strictEqual(result, githubScmContext);
+        });
+    });
+
     describe('_canHandleWebhook', () => {
         const headers = { somekey: 'somevalue' };
         const payload = { hogekey: 'hogevalue' };
 
         it('returns true when desired scm found', () => {
-            const exampleScm = scm.scms['example.context'];
+            exampleScm = scm.scms[exampleScmContext];
 
             return scm._canHandleWebhook(headers, payload)
                 .then((result) => {
@@ -966,10 +902,6 @@ describe('index test', () => {
         });
 
         it('returns true when desired scm not found', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
             scmGithub.canHandleWebhook.resolves(false);
             exampleScm.canHandleWebhook.resolves(false);
             scmGitlab.canHandleWebhook.resolves(false);
@@ -985,12 +917,9 @@ describe('index test', () => {
     });
 
     describe('getDisplayName', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
         it('call origin getDisplayName', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
             const result = scm.getDisplayName(config);
 
             assert.strictEqual(result, 'example');
@@ -1001,12 +930,9 @@ describe('index test', () => {
     });
 
     describe('readOnlyEnabled', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
         it('call origin getDisplayName', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
             const result = scm.readOnlyEnabled(config);
 
             assert.strictEqual(result, 'example');
@@ -1017,12 +943,9 @@ describe('index test', () => {
     });
 
     describe('autoDeployKeyGenerationEnabled', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
         it('call origin autoDeployKeyGenerationEnabled', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
             const result = scm.autoDeployKeyGenerationEnabled(config);
 
             assert.strictEqual(result, 'example');
@@ -1033,12 +956,9 @@ describe('index test', () => {
     });
 
     describe('getWebhookEventsMapping', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
         it('call origin getWebhookEventsMapping', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
             const result = scm._getWebhookEventsMapping(config);
 
             assert.deepEqual(result, { pr: 'pull_request' });
@@ -1049,22 +969,18 @@ describe('index test', () => {
     });
 
     describe('_getBranchList', () => {
-        const config = { scmContext: 'example.context' };
+        const config = { scmContext: exampleScmContext };
 
-        it('call origin getBranchList', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._getBranchList(config)
+        it('call origin getBranchList', () => (
+            scm._getBranchList(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.getBranchList);
                     assert.notCalled(scmGitlab.getBranchList);
                     assert.calledOnce(exampleScm.getBranchList);
                     assert.calledWith(exampleScm.getBranchList, config);
-                });
-        });
+                })
+        ));
     });
 
     describe('_openPr', () => {
@@ -1080,22 +996,18 @@ describe('index test', () => {
             }],
             title: 'update file',
             message: 'update file',
-            scmContext: 'example.context'
+            scmContext: exampleScmContext
         };
 
-        it('call origin openPr', () => {
-            const scmGithub = scm.scms['github.context'];
-            const exampleScm = scm.scms['example.context'];
-            const scmGitlab = scm.scms['gitlab.context'];
-
-            return scm._openPr(config)
+        it('call origin openPr', () => (
+            scm._openPr(config)
                 .then((result) => {
                     assert.strictEqual(result, 'example');
                     assert.notCalled(scmGithub.openPr);
                     assert.notCalled(scmGitlab.openPr);
                     assert.calledOnce(exampleScm.openPr);
                     assert.calledWith(exampleScm.openPr, config);
-                });
-        });
+                }))
+        );
     });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,7 +38,6 @@ describe('index test', () => {
             'dummyRejectFunction',
             'addWebhook',
             'addDeployKey',
-            'autoDeployKeyGenerationEnabled',
             'parseUrl',
             'parseHook',
             'getCheckoutCommand',
@@ -66,6 +65,7 @@ describe('index test', () => {
         mock.canHandleWebhook = sinon.stub().resolves(true);
         mock.getScmContexts = sinon.stub().returns([`${plugin}.context`]);
         mock.getDisplayName = sinon.stub().returns(plugin);
+        mock.readOnlyEnabled = sinon.stub().returns(plugin);
         mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
         mock.getWebhookEventsMapping = sinon.stub().returns({ pr: 'pull_request' });
 
@@ -369,7 +369,7 @@ describe('index test', () => {
             );
         });
 
-        it('register a plugin', () => {
+        it('registers a plugin', () => {
             const config = Object.assign(
                 { displayName: 'example.com' },
                 examplePluginOptions
@@ -398,7 +398,7 @@ describe('index test', () => {
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
         });
 
-        it('does not throw an error when scm-router plugin be specified for scms setting', () => {
+        it('does not throw an error when scm-router plugin is specified for scms setting', () => {
             const config = Object.assign(
                 { displayName: 'example.com' },
                 examplePluginOptions
@@ -417,7 +417,7 @@ describe('index test', () => {
             assert.isUndefined(exampleScm);
         });
 
-        it('does not throw an error when npm module return empty scmContext', () => {
+        it('does not throw an error when npm module returns empty scmContext', () => {
             exampleScmMock.getScmContexts.returns(['']);
             const config = Object.assign(
                 { displayName: 'example.com' },
@@ -435,6 +435,19 @@ describe('index test', () => {
             assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
             assert.isUndefined(scmGitlab);
             assert.isUndefined(exampleScm);
+        });
+
+        it('does not throw an error when scmContext already exists', () => {
+            const config = Object.assign(
+                { displayName: 'github.com' },
+                examplePluginOptions
+            );
+
+            scm.loadPlugin('github', config);
+
+            const scmGithub = scm.scms['github.context'];
+
+            assert.deepEqual(scmGithub.constructorParams, expectedGithubOptions);
         });
     });
 
@@ -984,6 +997,22 @@ describe('index test', () => {
             assert.notCalled(scmGithub.getDisplayName);
             assert.notCalled(scmGitlab.getDisplayName);
             assert.calledOnce(exampleScm.getDisplayName);
+        });
+    });
+
+    describe('readOnlyEnabled', () => {
+        const config = { scmContext: 'example.context' };
+
+        it('call origin getDisplayName', () => {
+            const scmGithub = scm.scms['github.context'];
+            const exampleScm = scm.scms['example.context'];
+            const scmGitlab = scm.scms['gitlab.context'];
+            const result = scm.readOnlyEnabled(config);
+
+            assert.strictEqual(result, 'example');
+            assert.notCalled(scmGithub.readOnlyEnabled);
+            assert.notCalled(scmGitlab.readOnlyEnabled);
+            assert.calledOnce(exampleScm.readOnlyEnabled);
         });
     });
 


### PR DESCRIPTION
## Context

We need to get data from the SCM config: read-only flag, scmContext, username.

## Objective

This PR:
- adds `getReadOnlyInfo()` method to return read-only SCM config
- adds `getScmContext()` method to get `scmContext` based on `hostname`
- adds/fixes missing test for `loadPlugin()`, updates tests with proper scmContexts

## References

Related to https://github.com/screwdriver-cd/screwdriver/issues/2437

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
