### PR TITLE
fix: Semantic release in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,11 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/scm-router.git"
+    "url": "git+https://github.com/screwdriver-cd/scm-router.git"
   },
   "homepage": "https://github.com/screwdriver-cd/scm-router",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -50,9 +49,6 @@
     "screwdriver-scm-base": "^7.1.3"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context

Semantic release is failing to publish because it can't find noop package.

## Objective

This PR fixes semantic release.

## References

N/A

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
