### PR TITLE
feat: add fn _isEnterpriseUser

### DIFF
--- a/index.js
+++ b/index.js
@@ -478,6 +478,17 @@ class ScmRouter extends Scm {
     _openPr(config) {
         return this.chooseScm(config).then(scm => scm.openPr(config));
     }
+
+    /**
+     * Check if user belongs to an enterprise
+     * @method _isEnterpriseUser
+     * @param  {Object}     config              Configuration
+     * @param  {String}     config.scmContext   Name of scm context
+     * @return {Boolean}                        True if user belongs to an enterprise
+     */
+    _isEnterpriseUser(config) {
+        return this.chooseScm(config).then(scm => scm.isEnterpriseUser(config));
+    }
 }
 
 module.exports = ScmRouter;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -75,6 +75,7 @@ describe('index test', () => {
         mock.getReadOnlyInfo = sinon.stub().returns(plugin);
         mock.autoDeployKeyGenerationEnabled = sinon.stub().returns(plugin);
         mock.getWebhookEventsMapping = sinon.stub().returns({ pr: 'pull_request' });
+        mock.isEnterpriseUser = sinon.stub().returns(true);
 
         return mock;
     };
@@ -962,6 +963,19 @@ describe('index test', () => {
                 assert.notCalled(scmGitlab.openPr);
                 assert.calledOnce(exampleScm.openPr);
                 assert.calledWith(exampleScm.openPr, config);
+            }));
+    });
+
+    describe('_isEnterpriseUser', () => {
+        const config = { scmContext: exampleScmContext };
+
+        it('call origin _isEnterpriseUser', () =>
+            scm._isEnterpriseUser(config).then(result => {
+                assert.strictEqual(result, true);
+                assert.notCalled(scmGithub.isEnterpriseUser);
+                assert.notCalled(scmGitlab.isEnterpriseUser);
+                assert.calledOnce(exampleScm.isEnterpriseUser);
+                assert.calledWith(exampleScm.isEnterpriseUser, config);
             }));
     });
 });


### PR DESCRIPTION
## Context

`ScmRouter` needs to define the function `_isEnterpriseUser` to call the implemented method in `scm-github`

## Objective

This PR adds the `_isEnterpriseUser` fn.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
