### PR TITLE
fix(3225): handling when the webhook is incorrect [4]

### DIFF
--- a/index.js
+++ b/index.js
@@ -219,7 +219,7 @@ class ScmRouter extends Scm {
 
                 err.statusCode = 400;
 
-                throw err;
+                return Promise.reject(err);
             }
 
             return scm.parseHook(headers, payload);

--- a/index.js
+++ b/index.js
@@ -213,7 +213,13 @@ class ScmRouter extends Scm {
             if (!scm) {
                 logger.info('Webhook does not match any expected events or actions.');
 
-                return null;
+                const err = new Error(
+                    'Cannot parse this webhook. Please ensure that the signature is correct or that this SCM is supported.'
+                );
+
+                err.statusCode = 400;
+
+                throw err;
             }
 
             return scm.parseHook(headers, payload);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -615,7 +615,7 @@ describe('index test', () => {
                 assert.calledWith(exampleScm.parseHook, headers, payload);
             }));
 
-        it('throw error when all scm cannot parse the webhook', () => {
+        it('rejects error when all scm cannot parse the webhook', () => {
             scmGithub.canHandleWebhook.resolves(false);
             scmGitlab.canHandleWebhook.resolves(false);
             exampleScm.canHandleWebhook.resolves(false);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -614,6 +614,25 @@ describe('index test', () => {
                 assert.calledOnce(exampleScm.parseHook);
                 assert.calledWith(exampleScm.parseHook, headers, payload);
             }));
+
+        it('throw error when all scm cannot parse the webhook', () => {
+            scmGithub.canHandleWebhook.resolves(false);
+            scmGitlab.canHandleWebhook.resolves(false);
+            exampleScm.canHandleWebhook.resolves(false);
+
+            return scm
+                ._parseHook(headers, payload)
+                .then(() => {
+                    assert.fail('This should not fail the tests');
+                })
+                .catch(err => {
+                    assert.include(err.message, 'Cannot parse this webhook');
+                    assert.strictEqual(err.statusCode, 400);
+                    assert.notCalled(scmGithub.parseHook);
+                    assert.notCalled(scmGitlab.parseHook);
+                    assert.notCalled(exampleScm.parseHook);
+                });
+        });
     });
 
     describe('_getCheckoutCommand', () => {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

The `parseHook` method returns `null` when all scm instances do not accept the webhook.
So we cannnot know whether the webhook has correct signature at [here](https://github.com/screwdriver-cd/screwdriver/blob/ef31fca55eaff2548f7486795de41e84f87a675d/plugins/webhooks/index.js#L70-L73) because `null` is returned too when the webhook type is not supported.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

Throw error when all `scm` instances do not accept the webhook.
It will be able to see correctly that each `scm` accept the webhook or not by the following PRs.

- https://github.com/screwdriver-cd/scm-github/pull/238
- https://github.com/screwdriver-cd/scm-gitlab/pull/61
- https://github.com/screwdriver-cd/scm-bitbucket/pull/91

### Webhook response example

![example](https://github.com/user-attachments/assets/efb0216b-6852-4b9e-adbc-4b8553fe6ba9)

- Invalid signature webhook
- Not support hook event

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

Issue
- https://github.com/screwdriver-cd/screwdriver/issues/3225

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
